### PR TITLE
pick time to output to catalog

### DIFF
--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -662,11 +662,11 @@ def match_filter(template_names, template_list, st, threshold,
                 ev.comments.append(Comment(text=thresh_str))
                 ev.comments.append(Comment(text=ccc_str))
                 ev.comments.append(Comment(text=used_chans))
+                min_template_tm = min([tr.stats.starttime for tr in template])
                 for tr in template:
                     if (tr.stats.station, tr.stats.channel) not in chans[i]:
                         continue
                     else:
-                        min_template_tm = min([tr.stats.starttime for tr in template])
                         pick_tm = detecttime + (tr.stats.starttime - min_template_tm)
                         wv_id = WaveformStreamID(network_code=tr.stats.network,
                                                  station_code=tr.stats.station,

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -666,8 +666,7 @@ def match_filter(template_names, template_list, st, threshold,
                     if (tr.stats.station, tr.stats.channel) not in chans[i]:
                         continue
                     else:
-                        pick_tm = detecttime + (tr.stats.starttime -
-                                                detecttime)
+                        pick_tm = detecttime #should this pick time be just the detect time
                         wv_id = WaveformStreamID(network_code=tr.stats.network,
                                                  station_code=tr.stats.station,
                                                  channel_code=tr.stats.channel)

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -666,7 +666,8 @@ def match_filter(template_names, template_list, st, threshold,
                     if (tr.stats.station, tr.stats.channel) not in chans[i]:
                         continue
                     else:
-                        pick_tm = detecttime #should this pick time be just the detect time
+                        min_template_tm = min([tr.stats.starttime for tr in template])
+                        pick_tm = detecttime + (tr.stats.starttime - min_template_tm)
                         wv_id = WaveformStreamID(network_code=tr.stats.network,
                                                  station_code=tr.stats.station,
                                                  channel_code=tr.stats.channel)


### PR DESCRIPTION
Should the pick time be just the detect time and not detecttime + template start time - detect time (which I think is just template start time)?
Since plotting the events in catalog will trim to around the pick time.  So choosing the template start time as pick time doesn't cut the stream around where the actual detection was?